### PR TITLE
Fix the FSF address in LICENSE-LGPL

### DIFF
--- a/LICENSE-LGPL
+++ b/LICENSE-LGPL
@@ -2,7 +2,7 @@
 		       Version 2.1, February 1999
 
 Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 Everyone is permitted to copy and distribute verbatim copies
 of this license document, but changing it is not allowed.
@@ -486,7 +486,7 @@ convey the exclusion of warranty; and each file should have at least the
 
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 Also add information on how to contact you by electronic and paper mail.
 


### PR DESCRIPTION
The license contains an incorrect address for the FSF, this patch updates the license to show the correct address as seen in http://www.gnu.org/licenses/lgpl-2.1.txt
