### PR TITLE
to prevent throwing IllegalArgumentException for MLevel.OFF

### DIFF
--- a/src/main/java/com/mchange/v2/log/log4j/Log4jMLog.java
+++ b/src/main/java/com/mchange/v2/log/log4j/Log4jMLog.java
@@ -145,7 +145,7 @@ public final class Log4jMLog extends MLog
                 return Level.DEBUG;
             else if (lvl == MLevel.INFO)
                 return Level.INFO;
-            else if (lvl == MLevel.INFO)
+            else if (lvl == MLevel.OFF)
                 return Level.OFF;
             else if (lvl == MLevel.SEVERE)
                 return Level.ERROR;


### PR DESCRIPTION
check for level "OFF" to prevent throwing IllegalArgumentException "Unknown level" for valid MLevels.
