### PR TITLE
including cause

### DIFF
--- a/src/main/java/com/mchange/lang/PotentiallySecondaryException.java
+++ b/src/main/java/com/mchange/lang/PotentiallySecondaryException.java
@@ -50,7 +50,7 @@ public class PotentiallySecondaryException extends Exception implements Potentia
 
     public PotentiallySecondaryException(String msg, Throwable t)
     {
-	super(msg);
+	super(msg, t);
 	this.nested = t;
     }
 


### PR DESCRIPTION
If I deliberately set wrong password, my JDBC driver throws:
`'org.postgresql.util.PSQLException: FATAL: password authentication failed for user "test"'`
When using c3p0 the cause is not included, my app gets root-cause:
`'com.mchange.v2.resourcepool.CannotAcquireResourceException: A ResourcePool could not acquire a resource from its primary factory or source.'`
