### PR TITLE
Store passed SQLState in SQLException

### DIFF
--- a/src/main/java/com/mchange/v2/sql/SqlUtils.java
+++ b/src/main/java/com/mchange/v2/sql/SqlUtils.java
@@ -115,8 +115,7 @@ public final class SqlUtils
 		msg = "An SQLException was provoked by the following failure: " + t.toString();
 	    if ( VersionUtils.isAtLeastJavaVersion14() )
 		{
-		    SQLException out = new SQLException(msg);
-		    out.initCause( t );
+		    SQLException out = new SQLException(msg, sqlState, t);
 		    return out;
 		}
 	    else


### PR DESCRIPTION
Hello,

this commit is about the following case.

<pre>
try {
    Connection connection = datasource.getConnection();
    //get connection from configured C3P0 pooled datasource
    // DB is down, so it causes the following exception
   ...
}
catch (SQLException e) {
    System.out.println(e.getSQLState());
     e.printStackTrace();
}
</pre>

The output is:
<pre>
null
java.sql.SQLException: Connections could not be acquired from the underlying database!
	at com.mchange.v2.sql.SqlUtils.toSQLException(SqlUtils.java:118)
	at com.mchange.v2.c3p0.impl.C3P0PooledConnectionPool.checkoutPooledConnection(C3P0PooledConnectionPool.java:690)
	at com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource.getConnection(AbstractPoolBackedDataSource.java:140)
....
Caused by: com.mchange.v2.resourcepool.CannotAcquireResourceException: A ResourcePool could not acquire a resource from its primary factory or source.
	at com.mchange.v2.resourcepool.BasicResourcePool.awaitAvailable(BasicResourcePool.java:1418)
	at com.mchange.v2.resourcepool.BasicResourcePool.prelimCheckoutResource(BasicResourcePool.java:606)
....
</pre>

[Corresponding code at com.mchange.v2.c3p0.impl.C3P0PooledConnectionPool.checkoutPooledConnection](https://github.com/swaldman/c3p0/blob/master/src/java/com/mchange/v2/c3p0/impl/C3P0PooledConnectionPool.java#L692):
<pre>
throw SqlUtils.toSQLException("Connections could not be acquired from the underlying database!", "08001", e);
</pre>
As seen, the above code passes SQLState of class '08' (Connection failure) to exception.

But the [com.mchange.v2.sql.SqlUtils.toSQLException](https://github.com/swaldman/mchange-commons-java/blob/master/src/main/java/com/mchange/v2/sql/SqlUtils.java#L116) ignores SQLState if passed Throwable is not instance of SQLException:
<pre>
if (t instanceof SQLException){
...
}
else {
...
	    if ( VersionUtils.isAtLeastJavaVersion14() ){
		    SQLException out = new SQLException(msg);
		    out.initCause( t );
		    return out;
            }
}
</pre>

So passed SQLState is not stored in SQLException. 
My commit fixes this.