### PR TITLE
FINE log level should allow to dump JVM threads in DeadlockDetector

### DIFF
--- a/src/main/java/com/mchange/v2/async/ThreadPoolAsynchronousRunner.java
+++ b/src/main/java/com/mchange/v2/async/ThreadPoolAsynchronousRunner.java
@@ -807,7 +807,7 @@ public final class ThreadPoolAsynchronousRunner implements AsynchronousRunner
                         logger.warning( sw.toString() );
                         pw.close(); //superfluous, but I feel better
                     }
-		    if ( logger.isLoggable( MLevel.FINEST ) )
+		    if ( logger.isLoggable( MLevel.FINE ) )
 		    {
                         StringWriter sw = new StringWriter( 4096 );
                         PrintWriter pw = new PrintWriter( sw );
@@ -819,7 +819,7 @@ public final class ThreadPoolAsynchronousRunner implements AsynchronousRunner
                         else
                             pw.print( stackTraces ); //already has an end-of-line
                         pw.flush(); //superfluous, but I feel better
-                        logger.finest( sw.toString() );
+                        logger.fine( sw.toString() );
                         pw.close(); //superfluous, but I feel better
 		    }
                     recreateThreadsAndTasks();


### PR DESCRIPTION
FINEST level is also used when adding tasks to queue,
so there are many messages with this level and it might hurt the performace to have all this logged.

Usually I only want the **"APPARENT DEADLOCK"** message and both the Task and JVM thread dumps,
so the level change would allow me do do this.

----------------------------
**My use-case:**
I want a custom Appender which will notify my on "APPARENT DEADLOCK" events - but I need to have the JVM thread dump logged somewhere.

So currently I can't set the appender to "FINEST" because it is **too Verbose** an it would hurt the log disk size and the performance.